### PR TITLE
fix: Update `build-system.requires` so package can be installed from source

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,7 @@ multi_line_output = 3 # Vertical Hanging Indent
 src_paths = "tap_chorusai"
 
 [build-system]
-# Uncomment the pinned version in favor of the git URL once
-# https://github.com/python-poetry/poetry-core/pull/257 is merged
-# and a new poetry-core 1.0.x is released
-# requires = ["poetry-core>=1.0.0"]
-requires = ["poetry-core @ git+https://github.com/python-poetry/poetry-core.git@master"]
+requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ multi_line_output = 3 # Vertical Hanging Indent
 src_paths = "tap_chorusai"
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
The `master` branch of poetry-core no longer exists, so installs of this are breaking :)